### PR TITLE
Fix deploy issue

### DIFF
--- a/.github/workflows/gatsby.yml
+++ b/.github/workflows/gatsby.yml
@@ -10,7 +10,7 @@ jobs:
       - name: npm install and build and deploy
         run: |
           npm install
-          npm run build
+          npm run deploy
       - uses: peaceiris/actions-gh-pages@v2
         env:
           ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}

--- a/.github/workflows/gatsby.yml
+++ b/.github/workflows/gatsby.yml
@@ -16,4 +16,7 @@ jobs:
           ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           PUBLISH_BRANCH: gh-pages
           PUBLISH_DIR: ./public
+        with:
+          username: "yuxiang660"
+          useremail: "yuxiang660@163.com"
           

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "deploy": "gatsby build --prefix-paths && gh-pages -d public",
+    "pubdeploy": "gatsby build --prefix-paths && gh-pages -d public",
+    "deploy": "gatsby build --prefix-paths",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
   }
 }


### PR DESCRIPTION
To fix web site incorrect after action, use "npm run deploy" instead of "npm run build". Otherwise, the web site doesn't include the prefix.